### PR TITLE
Updates to allow new project to run successfully

### DIFF
--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.2"
-        minSdkVersion = 16
+        minSdkVersion = 21
         compileSdkVersion = 29
         targetSdkVersion = 29
     }

--- a/template/android/build.gradle
+++ b/template/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:3.5.3")
+        classpath("com.android.tools.build:gradle:4.1.0")
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/template/android/gradle/wrapper/gradle-wrapper.properties
+++ b/template/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/template/package.json
+++ b/template/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "android": "react-native run-android",
     "ios": "react-native run-ios",
+    "tvos": "react-native run-ios --simulator \"Apple TV\" --scheme \"HelloWorld-tvOS\"",
     "start": "react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"


### PR DESCRIPTION
I had all kinds of issues getting a new project to run.  I followed the advice at the following 2 links, which led to the attached change.  Everything else on my Mac is up to date.  I can now succesfully run the project on tvOS (see updated package.json run:ios entry) and Android TV.

* https://reactnative.dev/docs/environment-setup
* https://github.com/facebook/react-native/issues/29829#issuecomment-727280671

### react-native system info

```
$ npx react-native info
info Fetching system and libraries information...
System:
    OS: macOS 11.5.2
    CPU: (16) x64 Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
    Memory: 1.50 GB / 16.00 GB
    Shell: 3.2.57 - /bin/bash
  Binaries:
    Node: 14.16.1 - ~/.nvm/versions/node/v14.16.1/bin/node
    Yarn: Not Found
    npm: 6.14.12 - ~/.nvm/versions/node/v14.16.1/bin/npm
    Watchman: 2021.09.06.00 - /usr/local/bin/watchman
  Managers:
    CocoaPods: 1.10.1 - /Users/mdg/.rvm/gems/ruby-2.7.0/bin/pod
  SDKs:
    iOS SDK:
      Platforms: iOS 14.5, DriverKit 20.4, macOS 11.3, tvOS 14.5, watchOS 7.4
    Android SDK:
      API Levels: 27, 28, 29
      Build Tools: 28.0.3, 29.0.2, 30.0.3, 31.0.0
      System Images: android-22 | Android TV Intel x86 Atom, android-28 | Android TV Intel x86 Atom, android-29 | Intel x86 Atom_64
      Android NDK: Not Found
  IDEs:
    Android Studio: 2020.3 AI-203.7717.56.2031.7678000
    Xcode: 12.5.1/12E507 - /usr/bin/xcodebuild
  Languages:
    Java: javac 13 - /usr/bin/javac
  npmPackages:
    @react-native-community/cli: Not Found
    react: 17.0.1 => 17.0.1
    react-native: Not Found
    react-native-macos: Not Found
    react-native-tvos:  0.64.2-2
  npmGlobalPackages:
    *react-native*: Not Found
```