### PR TITLE
Fix UIRequiredDeviceCapabilities key

### DIFF
--- a/template/ios/HelloWorld-tvOS/Info.plist
+++ b/template/ios/HelloWorld-tvOS/Info.plist
@@ -39,7 +39,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>

--- a/template/ios/HelloWorld/Info.plist
+++ b/template/ios/HelloWorld/Info.plist
@@ -41,7 +41,7 @@
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
-		<string>armv7</string>
+		<string>arm64</string>
 	</array>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>


### PR DESCRIPTION
Fixes issue where asset validation would fail when pushing to the Appstore due to invalid key value on `Info.plist`.

> Asset validation failed (90108) This bundle is invalid. The key UIRequiredDeviceCapabilities in the Info.plist may not contain values that would prevent this application from running on any device